### PR TITLE
Fix freeze/crash issue when wrapping number boxes

### DIFF
--- a/Controls/NumberBox.xaml.cs
+++ b/Controls/NumberBox.xaml.cs
@@ -133,11 +133,11 @@ public partial class NumberBox : UserControl, INotifyPropertyChanged
 				{
 					double range = this.Maximum - this.Minimum;
 
-					while (this.Value > this.Maximum)
-						this.Value -= range;
+					if (this.Value > this.Maximum)
+						this.Value = this.Minimum + ((this.Value - this.Maximum) % range);
 
-					while (this.Value < this.Minimum)
-						this.Value += range;
+					if (this.Value < this.Minimum)
+						this.Value = this.Maximum - ((this.Maximum - this.Value) % range);
 				}
 
 				this.Value = Math.Max(this.Minimum, this.Value);


### PR DESCRIPTION
The current method of wrapping uses a while loop, which freezes or even crashes the program when operating on very large numbers. This solution fixes that problem by calculating the wrapped value arithmetically.