### PR TITLE
InvariantCulture in ConverterBase parameter

### DIFF
--- a/Converters/ConverterBase.cs
+++ b/Converters/ConverterBase.cs
@@ -50,7 +50,7 @@ public abstract class ConverterBase<TFrom, TTo, TParameter> : ConverterBase<TFro
 
 			if (typeof(TParameter) == typeof(double))
 			{
-				double val = System.Convert.ToDouble(base.Parameter);
+				double val = System.Convert.ToDouble(base.Parameter, CultureInfo.InvariantCulture);
 
 				if (val is TParameter tParameterVal)
 					return tParameterVal;


### PR DESCRIPTION
I'm not sure if this is good, but Anamnesis Studio didn't run for me until I did this since "0.5" wasn't a valid input with my culture settings.